### PR TITLE
remove engine reference for Node 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Also:
 
 `ember install ember-infinity`
 
-We test against `ember-source > 3.28`. Try out `v2.0.0`. If it doesn't work or you don't have the right polyfills because you are on an older Ember version, then `v1.4.9` will be your best bet.
+We test against `ember-source >= 3.28`. Try out `v2.0.0`. If it doesn't work or you don't have the right polyfills because you are on an older Ember version, then `v1.4.9` will be your best bet.
 
 ## Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Also:
 
 `ember install ember-infinity`
 
-As of `v2.0.0`, we support Node 10 and above. We test against `ember-source > 3.8`. Try out `v2.0.0`. If it doesn't work or you don't have the right polyfills because you are on an older Ember version, then `v1.4.9` will be your best bet.
+We test against `ember-source > 3.28`. Try out `v2.0.0`. If it doesn't work or you don't have the right polyfills because you are on an older Ember version, then `v1.4.9` will be your best bet.
 
 ## Basic Usage
 

--- a/ember-infinity/package.json
+++ b/ember-infinity/package.json
@@ -74,9 +74,6 @@
   "peerDependencies": {
     "ember-source": ">= 3.28.0"
   },
-  "engines": {
-    "node": ">= 18"
-  },
   "ember": {
     "edition": "octane"
   }


### PR DESCRIPTION
As this is now a v2 addon it doesn't care what version of node your consuming app is using 👍 