### PR TITLE
Account for isDestroying state on InfinityLoaderComponent

### DIFF
--- a/ember-infinity/src/components/infinity-loader.js
+++ b/ember-infinity/src/components/infinity-loader.js
@@ -177,7 +177,7 @@ export default class InfinityLoaderComponent extends Component {
     this._cancelTimers();
 
     this.infinityModelContent.then((infinityModel) => {
-      if (!this.isDestroyed) {
+      if (!this.isDestroyed && !this.isDestroying) {
         infinityModel.off(
           'infinityModelLoaded',
           this,


### PR DESCRIPTION
If the `InfinityLoaderComponent` has already had `destroy` called then `infinityMomdel` will be `null`.