### PR TITLE
Cleanup inViewport watcher

### DIFF
--- a/ember-infinity/src/components/infinity-loader.js
+++ b/ember-infinity/src/components/infinity-loader.js
@@ -176,6 +176,8 @@ export default class InfinityLoaderComponent extends Component {
     super.willDestroy(...arguments);
     this._cancelTimers();
 
+    this.inViewport.stopWatching(this.elem);
+
     this.infinityModelContent.then((infinityModel) => {
       if (!this.isDestroyed && !this.isDestroying) {
         infinityModel.off(


### PR DESCRIPTION
`inViewport.watchElement` is used on setup and needs to be cleaned up in order to prevent memory leaks caused by leftover watcher.