### PR TITLE
Fix infinity-loader not updating model when infinity reached

### DIFF
--- a/ember-infinity/src/components/infinity-loader.hbs
+++ b/ember-infinity/src/components/infinity-loader.hbs
@@ -20,4 +20,6 @@
       {{/if}}
     {{/if}}
   </div>
+{{else}}
+  <div {{did-update this._initialInfinityModelSetup @infinityModel}}></div>
 {{/if}}

--- a/test-app/tests/integration/infinity-loader-test.js
+++ b/test-app/tests/integration/infinity-loader-test.js
@@ -66,6 +66,40 @@ module('infinity-loader', function (hooks) {
     assert.notOk(find('[data-test-infinity-loader]'), 'Element is not found');
   });
 
+  test('hideOnInfinity works when reached infinity and changing model', async function (assert) {
+    this.infinityModel = {
+      name: 'dot',
+      reachedInfinity: true,
+      on: () => {},
+      off: () => {},
+    };
+    await render(hbs`
+      <InfinityLoader
+        @infinityModel={{this.infinityModel}}
+        @hideOnInfinity={{true}}
+        @infinity={{this.infinityServiceMock}}
+      />
+    `);
+
+    assert.notOk(find('[data-test-infinity-loader]'), 'Loader is not shown');
+
+    run(() => {
+      set(this, 'infinityModel', {
+        name: 'dot2',
+        reachedInfinity: false,
+        on: () => {},
+        off: () => {},
+      });
+    });
+
+    await waitUntil(
+      () => {
+        return find('[data-test-infinity-loader]') != null;
+      },
+      { timeoutMessage: 'Loader is shown' },
+    );
+  });
+
   test('hideOnInfinity does not work if hideOnInfinity=false', async function (assert) {
     this.infinityModel = {
       name: 'dot',


### PR DESCRIPTION
# Reason
In our application we allow changing filters that are passed to the infinity model, so we create a new infinity model. However, when the current model has reached infinity, updating the infinity model does not update within the infinity loader, so the new model does not load more pages.

I added a test that reflects this, and fixed it by adding an empty div when not shown, to host the `{{did-update}}`. Not an ideal solution, so let me know if there are other solutions 👍  